### PR TITLE
chore(colors): vim validate deprecation

### DIFF
--- a/lua/git-conflict/colors.lua
+++ b/lua/git-conflict/colors.lua
@@ -9,7 +9,11 @@ local rshift, band = bit.rshift, bit.band
 --@param rgb_24bit (number) 24-bit RGB value
 --@returns (table) with keys 'r', 'g', 'b' in [0,255]
 local function decode_24bit_rgb(rgb_24bit)
-  vim.validate({ rgb_24bit = { rgb_24bit, 'n', true } })
+  if vim.fn.has('nvim-0.11') == 1 then
+    vim.validate('rgb_24bit', rgb_24bit, 'number', true)
+  else
+    vim.validate({ rgb_24bit = { rgb_24bit, 'n', true } })
+  end
   local r = band(rshift(rgb_24bit, 16), 255)
   local g = band(rshift(rgb_24bit, 8), 255)
   local b = band(rgb_24bit, 255)


### PR DESCRIPTION
vim.validate now uses fewer tables with new signature